### PR TITLE
Fix bug in filtering to address from cc and bcc list (bump #patch)

### DIFF
--- a/src/main/java/ses/notification/lambda/reports/Report.java
+++ b/src/main/java/ses/notification/lambda/reports/Report.java
@@ -5,6 +5,7 @@ import ses.notification.lambda.SesMessageMail;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
+import java.util.stream.Collectors;
 
 /**
  * A SES message report.
@@ -33,8 +34,9 @@ public interface Report<T> {
         if (!to.isEmpty()) {
             sb.append(TO).append(joinStrings(to)).append("\n");
         }
-        final List<String> ccAndBcc = new ArrayList<>(readList(mail.getDestination()));
-        ccAndBcc.removeAll(to);
+        final List<String> ccAndBcc = copyList(mail).stream()
+                                                    .filter(ccAndBCC -> addressNotIncludedIn(ccAndBCC, to))
+                                                    .collect(Collectors.toList());
         if (!ccAndBcc.isEmpty()) {
             sb.append(CC_AND_BCC).append(joinStrings(ccAndBcc)).append("\n");
         }
@@ -44,6 +46,14 @@ public interface Report<T> {
         }
 
         return sb.toString();
+    }
+
+    private static boolean addressNotIncludedIn(String address, List<String> to) {
+        return to.stream().noneMatch(addressWithName -> addressWithName.contains(address));
+    }
+
+    private static ArrayList<String> copyList(SesMessageMail mail) {
+        return new ArrayList<>(readList(mail.getDestination()));
     }
 
     private static String joinStrings(List<String> list) {

--- a/src/test/java/ses/notification/lambda/EmailReportingServiceTest.java
+++ b/src/test/java/ses/notification/lambda/EmailReportingServiceTest.java
@@ -10,10 +10,15 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static ses.notification.lambda.TestDataFactory.REPLY_TO_1_EMAIL_COM;
 import static ses.notification.lambda.TestDataFactory.REPLY_TO_2_EMAIL_COM;
 import static ses.notification.lambda.TestDataFactory.TEST_1_EMAIL_COM;
+import static ses.notification.lambda.TestDataFactory.TEST_1_EMAIL_COM_WITH_NAME;
 import static ses.notification.lambda.TestDataFactory.TEST_2_EMAIL_COM;
 import static ses.notification.lambda.reports.BounceEmailReport.BOUNCE_BODY_ADDRESS_LIST_HEADER;
 import static ses.notification.lambda.reports.BounceEmailReport.BOUNCE_BODY_HEADER;
+import static ses.notification.lambda.reports.BounceEmailReport.BOUNCE_DESCRIPTION_HEADER;
 import static ses.notification.lambda.reports.BounceEmailReport.BOUNCE_REPORT_SUBJECT;
+import static ses.notification.lambda.reports.Report.CC_AND_BCC;
+import static ses.notification.lambda.reports.Report.REPLY_TO;
+import static ses.notification.lambda.reports.Report.TO;
 
 @MicronautTest
 class EmailReportingServiceTest {
@@ -45,10 +50,10 @@ class EmailReportingServiceTest {
         assertThat(email.getBody().get(BodyType.TEXT)).isPresent();
         assertThat(email.getBody().get(BodyType.TEXT).get()).contains(BOUNCE_BODY_HEADER)
                                                             .contains(BOUNCE_BODY_ADDRESS_LIST_HEADER)
-                                                            .contains(TEST_1_EMAIL_COM)
-                                                            .contains(TEST_2_EMAIL_COM)
-                                                            .contains(REPLY_TO_1_EMAIL_COM)
-                                                            .contains(REPLY_TO_2_EMAIL_COM)
+                                                            .contains(BOUNCE_DESCRIPTION_HEADER)
+                                                            .contains(TO + TEST_1_EMAIL_COM_WITH_NAME)
+                                                            .contains(CC_AND_BCC + TEST_2_EMAIL_COM)
+                                                            .contains(REPLY_TO + REPLY_TO_1_EMAIL_COM + ", " + REPLY_TO_2_EMAIL_COM)
                                                             .contains("Bounce Type: Permanent (General)");
     }
 

--- a/src/test/java/ses/notification/lambda/TestDataFactory.java
+++ b/src/test/java/ses/notification/lambda/TestDataFactory.java
@@ -10,7 +10,9 @@ public class TestDataFactory {
 
     private static final ObjectMapper MAPPER = new ObjectMapper();
     public static final String TEST_1_EMAIL_COM = "test1@email.com";
+    public static final String TEST_1_EMAIL_COM_WITH_NAME = String.format("Test 1 <%s>", TEST_1_EMAIL_COM);
     public static final String TEST_2_EMAIL_COM = "test2@email.com";
+    public static final String TEST_2_EMAIL_COM_WITH_NAME = String.format("Test 2 <%s>", TEST_2_EMAIL_COM);
     public static final String TEST_SUBJECT = "Test subject";
     public static final String FROM_1_EMAIL_COM = "from1@email.com";
     public static final String FROM_2_EMAIL_COM = "from2@email.com";
@@ -70,7 +72,7 @@ public class TestDataFactory {
         final SesMessageMail.CommonHeaders commonHeaders = new SesMessageMail.CommonHeaders();
         commonHeaders.setSubject(TEST_SUBJECT);
         commonHeaders.setFrom(List.of(FROM_1_EMAIL_COM, FROM_2_EMAIL_COM));
-        commonHeaders.setTo(List.of(TEST_1_EMAIL_COM));
+        commonHeaders.setTo(List.of(TEST_1_EMAIL_COM_WITH_NAME));
         commonHeaders.setReplyTo(List.of(REPLY_TO_1_EMAIL_COM, REPLY_TO_2_EMAIL_COM));
         mail.setCommonHeaders(commonHeaders);
         message.setMail(mail);


### PR DESCRIPTION
This PR fixes a bug that prevented the correct filtering of the TO address from the list of addresses in the CC and BCC fields.