### PR TITLE
Include error message in bounced address report

### DIFF
--- a/src/main/java/ses/notification/lambda/reports/BounceEmailReport.java
+++ b/src/main/java/ses/notification/lambda/reports/BounceEmailReport.java
@@ -4,6 +4,7 @@ import lombok.extern.slf4j.Slf4j;
 import ses.notification.lambda.ReportingConfiguration;
 import ses.notification.lambda.SesBounceMessage;
 
+import java.util.Objects;
 import java.util.stream.Collectors;
 
 @Slf4j
@@ -14,6 +15,8 @@ public class BounceEmailReport extends EmailReport {
     public static final String BOUNCE_DESCRIPTION_HEADER = "Details of this bounce are:\n\n";
     public static final String BOUNCE_BODY_ADDRESS_LIST_HEADER = "The addresses for which the email bounced are:\n";
     public static final String BOUNCE_TYPE = "\tBounce Type: ";
+    public static final String BOUNCED_ADDRESS_ERROR_MESSAGE = ", Error message: ";
+    public static final String NA = "NA";
 
     private String bounceType;
     private String bounceReason;
@@ -40,8 +43,13 @@ public class BounceEmailReport extends EmailReport {
     private static String getListOfBouncedAddresses(SesBounceMessage.Bounce bounce) {
         return bounce.getBouncedRecipients()
                      .stream()
-                     .map(SesBounceMessage.BounceRecipients::getEmailAddress)
-                     .map(address -> "  - " + address)
+                     .map(BounceEmailReport::buildAddressLine)
                      .collect(Collectors.joining("\n"));
+    }
+
+    private static String buildAddressLine(SesBounceMessage.BounceRecipients bounceRecipients) {
+        String diagnosticCode = Objects.requireNonNullElse(bounceRecipients.getDiagnosticCode(), NA);
+        diagnosticCode = diagnosticCode.isBlank() ? NA : diagnosticCode;
+        return "  - Address: " + bounceRecipients.getEmailAddress() + BOUNCED_ADDRESS_ERROR_MESSAGE + diagnosticCode;
     }
 }

--- a/src/test/java/ses/notification/lambda/EmailReportingServiceTest.java
+++ b/src/test/java/ses/notification/lambda/EmailReportingServiceTest.java
@@ -12,14 +12,18 @@ import static ses.notification.lambda.TestDataFactory.REPLY_TO_2_EMAIL_COM;
 import static ses.notification.lambda.TestDataFactory.TEST_1_EMAIL_COM;
 import static ses.notification.lambda.TestDataFactory.TEST_1_EMAIL_COM_WITH_NAME;
 import static ses.notification.lambda.TestDataFactory.TEST_2_EMAIL_COM;
+import static ses.notification.lambda.TestDataFactory.THE_ACCOUNT_DOES_NOT_EXIST;
+import static ses.notification.lambda.reports.BounceEmailReport.BOUNCED_ADDRESS_ERROR_MESSAGE;
 import static ses.notification.lambda.reports.BounceEmailReport.BOUNCE_BODY_ADDRESS_LIST_HEADER;
 import static ses.notification.lambda.reports.BounceEmailReport.BOUNCE_BODY_HEADER;
 import static ses.notification.lambda.reports.BounceEmailReport.BOUNCE_DESCRIPTION_HEADER;
 import static ses.notification.lambda.reports.BounceEmailReport.BOUNCE_REPORT_SUBJECT;
+import static ses.notification.lambda.reports.BounceEmailReport.NA;
 import static ses.notification.lambda.reports.Report.CC_AND_BCC;
 import static ses.notification.lambda.reports.Report.REPLY_TO;
 import static ses.notification.lambda.reports.Report.TO;
 
+@SuppressWarnings({"OptionalGetWithoutIsPresent", "ConstantConditions"})
 @MicronautTest
 class EmailReportingServiceTest {
 
@@ -54,7 +58,25 @@ class EmailReportingServiceTest {
                                                             .contains(TO + TEST_1_EMAIL_COM_WITH_NAME)
                                                             .contains(CC_AND_BCC + TEST_2_EMAIL_COM)
                                                             .contains(REPLY_TO + REPLY_TO_1_EMAIL_COM + ", " + REPLY_TO_2_EMAIL_COM)
-                                                            .contains("Bounce Type: Permanent (General)");
+                                                            .contains("Bounce Type: Permanent (General)")
+                                                            .contains(TEST_1_EMAIL_COM + BOUNCED_ADDRESS_ERROR_MESSAGE + THE_ACCOUNT_DOES_NOT_EXIST);
+    }
+
+    @Test
+    void reportBounce_withMultipleAddresses_and_noErrorMessage() {
+        final Email email = service.report(TestDataFactory.bounceNotificationMultipleToAddressesNoDiagnosticsCode());
+
+        assertThat(email).isNotNull();
+        assertThat(email.getSubject()).isEqualTo(BOUNCE_REPORT_SUBJECT);
+        assertThat(email.getBody().get(BodyType.TEXT)).isPresent();
+        assertThat(email.getBody().get(BodyType.TEXT).get()).contains(BOUNCE_BODY_HEADER)
+                                                            .contains(BOUNCE_BODY_ADDRESS_LIST_HEADER)
+                                                            .contains(BOUNCE_DESCRIPTION_HEADER)
+                                                            .contains(TO + TEST_1_EMAIL_COM_WITH_NAME)
+                                                            .contains(CC_AND_BCC + TEST_2_EMAIL_COM)
+                                                            .contains(REPLY_TO + REPLY_TO_1_EMAIL_COM + ", " + REPLY_TO_2_EMAIL_COM)
+                                                            .contains("Bounce Type: Permanent (General)")
+                                                            .contains(TEST_1_EMAIL_COM + BOUNCED_ADDRESS_ERROR_MESSAGE + NA);
     }
 
 

--- a/src/test/java/ses/notification/lambda/TestDataFactory.java
+++ b/src/test/java/ses/notification/lambda/TestDataFactory.java
@@ -18,6 +18,7 @@ public class TestDataFactory {
     public static final String FROM_2_EMAIL_COM = "from2@email.com";
     public static final String REPLY_TO_2_EMAIL_COM = "replyto2@email.com";
     public static final String REPLY_TO_1_EMAIL_COM = "replyto1@email.com";
+    public static final String THE_ACCOUNT_DOES_NOT_EXIST = "The account does not exist.";
 
     static SNSEvent snsEvent(SesNotification message) throws JsonProcessingException {
         final SNSEvent event = new SNSEvent();
@@ -63,7 +64,31 @@ public class TestDataFactory {
                                                  .emailAddress(TEST_1_EMAIL_COM)
                                                  .action("failed")
                                                  .status("5.1.1")
-                                                 .diagnosticCode("The account does not exist.")
+                                                 .diagnosticCode(THE_ACCOUNT_DOES_NOT_EXIST)
+                                                 .build()
+        ));
+        message.setBounce(bounce);
+        final SesMessageMail mail = new SesMessageMail();
+        mail.setDestination(List.of(TEST_1_EMAIL_COM, TEST_2_EMAIL_COM));
+        final SesMessageMail.CommonHeaders commonHeaders = new SesMessageMail.CommonHeaders();
+        commonHeaders.setSubject(TEST_SUBJECT);
+        commonHeaders.setFrom(List.of(FROM_1_EMAIL_COM, FROM_2_EMAIL_COM));
+        commonHeaders.setTo(List.of(TEST_1_EMAIL_COM_WITH_NAME));
+        commonHeaders.setReplyTo(List.of(REPLY_TO_1_EMAIL_COM, REPLY_TO_2_EMAIL_COM));
+        mail.setCommonHeaders(commonHeaders);
+        message.setMail(mail);
+
+        return message;
+    }
+
+    static SesBounceMessage bounceNotificationMultipleToAddressesNoDiagnosticsCode() {
+        final SesBounceMessage message = new SesBounceMessage();
+        final SesBounceMessage.Bounce bounce = new SesBounceMessage.Bounce();
+        bounce.setBounceType("Permanent");
+        bounce.setBounceSubType("General");
+        bounce.setBouncedRecipients(List.of(
+                SesBounceMessage.BounceRecipients.builder()
+                                                 .emailAddress(TEST_1_EMAIL_COM)
                                                  .build()
         ));
         message.setBounce(bounce);


### PR DESCRIPTION
This PR includes the error message for bounced email addresses, or `NA` if no message is avaialble.